### PR TITLE
Fix finish checkpoint height

### DIFF
--- a/Demo/Shared/Scenes/Level Logic/RestartAtCheckpointScene.swift
+++ b/Demo/Shared/Scenes/Level Logic/RestartAtCheckpointScene.swift
@@ -58,7 +58,8 @@ class RestartAtCheckpointScene: BaseLevelScene {
                                           spawnDirection: TransformNodeComponent.HeadingDirection.right)
         let finishCheckpointEntity = EntityFactory.checkpointEntity(checkpoint: finishCheckpoint,
                                                                     checkpointWidthInTiles: 3,
-                                                                    tileSize: tileSize)
+                                                                    tileSize: tileSize,
+                                                                    isFinish: true)
         addEntity(finishCheckpointEntity)
         
         addEntity(gemCounterEntity)

--- a/Demo/Shared/Scenes/Level Logic/RestartAtCheckpointScene.swift
+++ b/Demo/Shared/Scenes/Level Logic/RestartAtCheckpointScene.swift
@@ -59,7 +59,7 @@ class RestartAtCheckpointScene: BaseLevelScene {
         let finishCheckpointEntity = EntityFactory.checkpointEntity(checkpoint: finishCheckpoint,
                                                                     checkpointWidthInTiles: 3,
                                                                     tileSize: tileSize,
-                                                                    isFinish: true)
+                                                                    stretchesToTop: true)
         addEntity(finishCheckpointEntity)
         
         addEntity(gemCounterEntity)

--- a/Sources/Entities/Convenience/EntityFactory.swift
+++ b/Sources/Entities/Convenience/EntityFactory.swift
@@ -113,16 +113,16 @@ public class EntityFactory {
     public static func checkpointEntity(checkpoint: Checkpoint,
                                         checkpointWidthInTiles: Int,
                                         tileSize: CGSize,
-                                        isFinish: Bool = false) -> GlideEntity {
+                                        stretchesToTop: Bool = false) -> GlideEntity {
         let entity = GlideEntity(initialNodePosition: checkpoint.bottomLeftPosition.point(with: tileSize))
         entity.name = "Checkpoint-\(checkpoint.id)"
         entity.transform.usesProposedPosition = false
         
-        let checkpointComponent = CheckpointComponent(checkpoint: checkpoint, adjustsColliderSize: !isFinish)
+        let checkpointComponent = CheckpointComponent(checkpoint: checkpoint, adjustsColliderSize: !stretchesToTop)
         entity.addComponent(checkpointComponent)
         
         let colliderWidth = CGFloat(checkpointWidthInTiles) * tileSize.width
-        let colliderHeight = isFinish ? CGFloat(checkpointWidthInTiles) * tileSize.height : 0
+        let colliderHeight = stretchesToTop ? CGFloat(checkpointWidthInTiles) * tileSize.height : 0
         let colliderComponent = ColliderComponent(categoryMask: GlideCategoryMask.snappable,
                                                   size: CGSize(width: colliderWidth, height: colliderHeight),
                                                   offset: .zero,

--- a/Sources/Entities/Convenience/EntityFactory.swift
+++ b/Sources/Entities/Convenience/EntityFactory.swift
@@ -112,17 +112,19 @@ public class EntityFactory {
     ///     - tileSize: Tile size of the scene.
     public static func checkpointEntity(checkpoint: Checkpoint,
                                         checkpointWidthInTiles: Int,
-                                        tileSize: CGSize) -> GlideEntity {
+                                        tileSize: CGSize,
+                                        isFinish: Bool = false) -> GlideEntity {
         let entity = GlideEntity(initialNodePosition: checkpoint.bottomLeftPosition.point(with: tileSize))
         entity.name = "Checkpoint-\(checkpoint.id)"
         entity.transform.usesProposedPosition = false
         
-        let checkpointComponent = CheckpointComponent(checkpoint: checkpoint)
+        let checkpointComponent = CheckpointComponent(checkpoint: checkpoint, adjustsColliderSize: !isFinish)
         entity.addComponent(checkpointComponent)
         
         let colliderWidth = CGFloat(checkpointWidthInTiles) * tileSize.width
+        let colliderHeight = isFinish ? CGFloat(checkpointWidthInTiles) * tileSize.height : 0
         let colliderComponent = ColliderComponent(categoryMask: GlideCategoryMask.snappable,
-                                                  size: CGSize(width: colliderWidth, height: 0),
+                                                  size: CGSize(width: colliderWidth, height: colliderHeight),
                                                   offset: .zero,
                                                   leftHitPointsOffsets: (0, 0),
                                                   rightHitPointsOffsets: (0, 0),


### PR DESCRIPTION
For finish checkpoints, as for all checkpoints, the height of the collider component was always set to `(screenSize - leftBottomCorner)`, meaning finish checkpoints were always "stretched" to the top. 

That limited the options for level design, because putting a finish checkpoint in the bottom of the level would mean that the same X position on other levels higher than the actual finish checkpoint would count as such (meaning you couldn't walk just above the checkpoint).

To fix that I added a `isFinish` parameter which would set `CheckpointComponent.adjustsColliderSize` to `false` to keep the original height of the collider.
Also updated _RestartAtCheckpointScene_ to showcase the setting.

| Before | After |
|- | - |
| <img width="577" alt="before" src="https://user-images.githubusercontent.com/25707957/235382755-43e1aeaa-9959-44f4-9943-ad5b3f5f3c59.png"> | <img width="636" alt="after" src="https://user-images.githubusercontent.com/25707957/235382753-8bcff791-c92c-4026-81af-1b6793c055d1.png"> |